### PR TITLE
Feature/scrolling and recomposition

### DIFF
--- a/app/src/main/java/rick_and_morty/ui/characters/CharactersFragment.kt
+++ b/app/src/main/java/rick_and_morty/ui/characters/CharactersFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
 import androidx.fragment.app.Fragment
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -17,6 +18,7 @@ class CharactersFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 CharacterList()
             }

--- a/app/src/main/java/rick_and_morty/ui/characters/CharactersViewModel.kt
+++ b/app/src/main/java/rick_and_morty/ui/characters/CharactersViewModel.kt
@@ -24,8 +24,8 @@ class CharactersViewModel @Inject constructor(
     val characters: StateFlow<List<CharacterResultsDto>> = _characters
 
     init {
-        getCharacters()
         initialLoad = false
+        getCharacters()
     }
 
     fun getCharacters() {

--- a/app/src/main/java/rick_and_morty/ui/characters/composables/CharacterList.kt
+++ b/app/src/main/java/rick_and_morty/ui/characters/composables/CharacterList.kt
@@ -1,28 +1,46 @@
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.lazy.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.launch
 import rick_and_morty.ui.characters.CharactersViewModel
 
 @Composable
 fun CharacterList(charactersViewModel: CharactersViewModel = viewModel(modelClass = CharactersViewModel::class.java)) {
 
     val characters = charactersViewModel.characters.collectAsState(emptyList())
-    LazyColumn (
-        verticalArrangement = Arrangement.spacedBy(5.dp)
-    ) {
+    val scrollListState = rememberLazyListState()
 
-        items(characters.value) {characters ->
+    LazyColumn (
+        verticalArrangement = Arrangement.spacedBy(5.dp),
+        state = scrollListState
+    ) {
+        items(characters.value) { characters ->
             CharacterRow(characterResultsDto = characters)
         }
-        item {
-            LaunchedEffect(true) {
-                    charactersViewModel.getCharacters()
-          }
+    }
+    val userIsAtBottom by remember{
+        derivedStateOf {
+            val layoutInfo = scrollListState.layoutInfo
+            val visibleItemsInfo = layoutInfo.visibleItemsInfo
+            if (layoutInfo.totalItemsCount == 0) {
+                false
+            } else {
+                val lastVisibleItem = visibleItemsInfo.last()
+                val viewportHeight = layoutInfo.viewportEndOffset + layoutInfo.viewportStartOffset
+                (lastVisibleItem.index + 1 == layoutInfo.totalItemsCount &&
+                        lastVisibleItem.offset + lastVisibleItem.size <= viewportHeight)
+            }
+        }
+    }
+    if (userIsAtBottom){
+        LaunchedEffect(true) {
+            charactersViewModel.getCharacters()
         }
     }
 }


### PR DESCRIPTION
## Context 
Previously my list was called several times during scroll, and during rotation user lost its position. I created ScrollListListener, call next page only when the user is below, and fixed my mistake of initialload assign in the viewmodel

## Changes 
- `CharacterList` added listener, and replaced logic of adding new page