### PR TITLE
Feature/pull to refresh

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.navigation:navigation-compose:2.7.0-alpha01"
+    implementation 'com.google.accompanist:accompanist-swiperefresh:0.31.3-beta'
 
     // Navigation Component
     implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application

--- a/app/src/main/java/rick_and_morty/data/realm/RealmInstance.kt
+++ b/app/src/main/java/rick_and_morty/data/realm/RealmInstance.kt
@@ -6,4 +6,5 @@ import rick_and_morty.data.model.episodes.EpisodeResultDto
 interface RealmInstance {
     fun <T : RealmObject> findAll(clazz: Class<T>): List<T>
     fun saveEpisodesToDatabase(episodesList: List<EpisodeResultDto>)
+    fun clearEpisodesDatabase()
 }

--- a/app/src/main/java/rick_and_morty/data/realm/RealmInstanceImplementation.kt
+++ b/app/src/main/java/rick_and_morty/data/realm/RealmInstanceImplementation.kt
@@ -3,6 +3,7 @@ package rick_and_morty.data.realm
 import io.realm.Realm
 import io.realm.RealmObject
 import rick_and_morty.data.model.episodes.EpisodeResultDto
+import rick_and_morty.data.model.episodes.realm.RealmEpisodes
 import rick_and_morty.ui.episodes.EpisodesMapper.toRealmEpisode
 
 class RealmInstanceImplementation(private val realm: Realm) : RealmInstance {
@@ -17,4 +18,11 @@ class RealmInstanceImplementation(private val realm: Realm) : RealmInstance {
             realm.copyToRealmOrUpdate(realmEpisodes)
         }
     }
+
+    override fun clearEpisodesDatabase() {
+        realm.executeTransaction { realm ->
+            realm.delete(RealmEpisodes::class.java)
+        }
+    }
+
 }

--- a/app/src/main/java/rick_and_morty/data/repository/EpisodesRepository.kt
+++ b/app/src/main/java/rick_and_morty/data/repository/EpisodesRepository.kt
@@ -15,6 +15,9 @@ class EpisodesRepository @Inject constructor(
     suspend fun getEpisodes(page: Int) =
         rickAndMortyApiRemoteDataSource.fetchRickAndMortyEpisodesData(page).results
 
+    suspend fun getEpisodesInfo(page: Int) =
+        rickAndMortyApiRemoteDataSource.fetchRickAndMortyEpisodesData(page).infoDto
+
     fun getEpisodesFromDatabase(): List<EpisodeResultDto> {
         val realmEpisodes = realmInstance.findAll(RealmEpisodes::class.java)
         return realmEpisodes.map { it.toEpisodesResultDto() }
@@ -23,5 +26,10 @@ class EpisodesRepository @Inject constructor(
     fun saveEpisodesToDatabase(episodesList: List<EpisodeResultDto>) {
         realmInstance.saveEpisodesToDatabase(episodesList)
     }
+
+    fun clearEpisodesDatabase() {
+        realmInstance.clearEpisodesDatabase()
+    }
+
 }
 

--- a/app/src/main/java/rick_and_morty/di/RickAndMortyApiModule.kt
+++ b/app/src/main/java/rick_and_morty/di/RickAndMortyApiModule.kt
@@ -1,5 +1,7 @@
 package rick_and_morty.di
 
+import android.app.Application
+import android.content.Context
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
@@ -40,22 +42,29 @@ private val moshi =
             .addConverterFactory(MoshiConverterFactory.create(moshi))
     }
 
-/*
-    private val moshi =
-        Moshi.Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
 
-    private val retrofit: Retrofit by lazy {
-        Retrofit.Builder()
-            .baseUrl(ApiConstants.BASE_URL)
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
+    @Provides
+    fun provideContext(application: Application): Context {
+        return application.applicationContext
+    }
+
+
+    /*
+        private val moshi =
+            Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
             .build()
-    }
 
-    val apiService: CharacterApiService by lazy {
-        retrofit.create(CharacterApiService::class.java)
-    }
+        private val retrofit: Retrofit by lazy {
+            Retrofit.Builder()
+                .baseUrl(ApiConstants.BASE_URL)
+                .addConverterFactory(MoshiConverterFactory.create(moshi))
+                .build()
+        }
 
-*/
+        val apiService: CharacterApiService by lazy {
+            retrofit.create(CharacterApiService::class.java)
+        }
+
+    */
 }

--- a/app/src/main/java/rick_and_morty/ui/RickAndMortyActivity.kt
+++ b/app/src/main/java/rick_and_morty/ui/RickAndMortyActivity.kt
@@ -12,6 +12,7 @@ import io.realm.RealmConfiguration
 import kotlinx.coroutines.launch
 import rick_and_morty.eventbus.EventBus
 import rick_and_morty.handleNavigation
+import rick_and_morty.utils.NetworkUtils
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -20,10 +21,22 @@ class RickAndMortyActivity : AppCompatActivity() {
     @Inject
     lateinit var eventBus: EventBus
 
+    @Inject
+    lateinit var realm: Realm
+
+    @Inject
+
+    lateinit var networkUtils: NetworkUtils
+
     private lateinit var navHostFragment: NavHostFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        if (networkUtils.isInternetAvailable())
+        {
+            realm.executeTransactionAsync { it.deleteAll() }
+        }
 
         setContentView(R.layout.activity_character)
 

--- a/app/src/main/java/rick_and_morty/ui/episodes/composables/EpisodesList.kt
+++ b/app/src/main/java/rick_and_morty/ui/episodes/composables/EpisodesList.kt
@@ -1,33 +1,33 @@
 package rick_and_morty.ui.episodes.composables
 
-import android.annotation.SuppressLint
+
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.BottomNavigation
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import androidx.navigation.NavController
-import rick_and_morty.BottomNavigationBar
-import rick_and_morty.eventbus.EventBus
-import rick_and_morty.ui.characters.CharactersViewModel
 import rick_and_morty.ui.episodes.EpisodesViewModel
 import rick_and_morty.ui.widgets.CircularProgressBar
 import rick_and_morty.ui.widgets.RickAndMortyErrorDialog
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun EpisodeList(
         episodesViewModel: EpisodesViewModel = viewModel(modelClass = EpisodesViewModel::class.java),
@@ -35,43 +35,50 @@ fun EpisodeList(
 
         val episodes = episodesViewModel.episodes.collectAsState().value
         val scrollListState = rememberLazyListState()
-        if (episodes.isLoading)
-        {
-                CircularProgressBar()
-        }
-        when {
-                episodes.isFailure -> RickAndMortyErrorDialog(episodes.failure.toString())
-                else -> {
-                        LazyColumn (
-                                modifier = Modifier.background(MaterialTheme.colorScheme.primary),
-                                verticalArrangement = Arrangement.spacedBy(5.dp),
-                                state = scrollListState
-                        ) {
-                                items(episodes.episodeResults) { episode ->
-                                        EpisodesRow(
-                                                episodeResultsDto = episode,
-                                          )
-                                }
-                        }
-                        val userIsAtBottom by remember{
-                                derivedStateOf {
-                                        val layoutInfo = scrollListState.layoutInfo
-                                        val visibleItemsInfo = layoutInfo.visibleItemsInfo
-                                        if (layoutInfo.totalItemsCount == 0) {
-                                                false
-                                        } else {
-                                                val lastVisibleItem = visibleItemsInfo.last()
-                                                val viewportHeight = layoutInfo.viewportEndOffset + layoutInfo.viewportStartOffset
-                                                (lastVisibleItem.index + 1 == layoutInfo.totalItemsCount &&
-                                                        lastVisibleItem.offset + lastVisibleItem.size <= viewportHeight)
+
+        val refreshing = episodes.isLoading
+        val swipeRefreshState = rememberPullRefreshState(refreshing, {episodesViewModel.refreshEpisodes()})
+
+        Box(modifier = Modifier.fillMaxSize().pullRefresh(swipeRefreshState)) {
+                if (episodes.isLoading && episodes.episodeResults.isEmpty()) {
+                        CircularProgressBar()
+                } else {
+                        when {
+                                episodes.isFailure -> RickAndMortyErrorDialog(episodes.failure.toString())
+                                else -> {
+                                        LazyColumn(
+                                                modifier = Modifier.background(MaterialTheme.colorScheme.primary),
+                                                verticalArrangement = Arrangement.spacedBy(5.dp),
+                                                state = scrollListState
+                                        ) {
+                                                items(episodes.episodeResults) { episode ->
+                                                        EpisodesRow(
+                                                                episodeResultsDto = episode,
+                                                        )
+                                                }
+                                        }
+                                        val userIsAtBottom by remember {
+                                                derivedStateOf {
+                                                        val layoutInfo = scrollListState.layoutInfo
+                                                        val visibleItemsInfo = layoutInfo.visibleItemsInfo
+                                                        if (layoutInfo.totalItemsCount == 0) {
+                                                                false
+                                                        } else {
+                                                                val lastVisibleItem = visibleItemsInfo.last()
+                                                                val viewportHeight = layoutInfo.viewportEndOffset + layoutInfo.viewportStartOffset
+                                                                (lastVisibleItem.index + 1 == layoutInfo.totalItemsCount &&
+                                                                        lastVisibleItem.offset + lastVisibleItem.size <= viewportHeight)
+                                                        }
+                                                }
+                                        }
+                                        if (userIsAtBottom) {
+                                                LaunchedEffect(true) {
+                                                        episodesViewModel.getEpisodes()
+                                                }
                                         }
                                 }
                         }
-                        if (userIsAtBottom){
-                                LaunchedEffect(true) {
-                                        episodesViewModel.getEpisodes()
-                                }
-                        }
+                        PullRefreshIndicator(refreshing, swipeRefreshState, Modifier.align(Alignment.TopCenter))
                 }
         }
 }

--- a/app/src/main/java/rick_and_morty/ui/episodes/composables/EpisodesList.kt
+++ b/app/src/main/java/rick_and_morty/ui/episodes/composables/EpisodesList.kt
@@ -36,8 +36,7 @@ fun EpisodeList(
         val episodes = episodesViewModel.episodes.collectAsState().value
         val scrollListState = rememberLazyListState()
 
-        val refreshing = episodes.isLoading
-        val swipeRefreshState = rememberPullRefreshState(refreshing, {episodesViewModel.refreshEpisodes()})
+        val swipeRefreshState = rememberPullRefreshState(episodes.isLoading, {episodesViewModel.refreshEpisodes()})
 
         Box(modifier = Modifier.fillMaxSize().pullRefresh(swipeRefreshState)) {
                 if (episodes.isLoading && episodes.episodeResults.isEmpty()) {
@@ -78,7 +77,7 @@ fun EpisodeList(
                                         }
                                 }
                         }
-                        PullRefreshIndicator(refreshing, swipeRefreshState, Modifier.align(Alignment.TopCenter))
+                        PullRefreshIndicator(episodes.isLoading, swipeRefreshState, Modifier.align(Alignment.TopCenter))
                 }
         }
 }

--- a/app/src/main/java/rick_and_morty/utils/NetworkUtils.kt
+++ b/app/src/main/java/rick_and_morty/utils/NetworkUtils.kt
@@ -1,0 +1,41 @@
+package rick_and_morty.utils
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Build
+import javax.inject.Inject
+
+
+class NetworkUtils @Inject constructor(private val context: Context) {
+    fun isInternetAvailable(): Boolean {
+        var result = false
+        val connectivityManager =
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val networkCapabilities = connectivityManager.activeNetwork ?: return false
+            val actNw =
+                connectivityManager.getNetworkCapabilities(networkCapabilities) ?: return false
+            result = when {
+                actNw.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> true
+                actNw.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> true
+                actNw.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> true
+                else -> false
+            }
+        } else {
+            connectivityManager.run {
+                connectivityManager.activeNetworkInfo?.run {
+                    result = when (type) {
+                        ConnectivityManager.TYPE_WIFI -> true
+                        ConnectivityManager.TYPE_MOBILE -> true
+                        ConnectivityManager.TYPE_ETHERNET -> true
+                        else -> false
+                    }
+
+                }
+            }
+        }
+
+        return result
+    }
+}

--- a/app/src/test/java/rick_and_morty/data/repository/EpisodesRepositoryTest.kt
+++ b/app/src/test/java/rick_and_morty/data/repository/EpisodesRepositoryTest.kt
@@ -32,23 +32,24 @@ class EpisodeRepositoryTest {
         episodeRepository = EpisodesRepository(mockApiRemoteDataSource, realmInstance)
     }
 
+    private val mockResponse = EpisodesResponseDto(
+        EpisodesInfoDto(51, 3, "https://rickandmortyapi.com/api/episode?page=2", null),
+        listOf(
+            EpisodeResultDto(
+                1,
+                "Pilot",
+                "December 2, 2013",
+                "S01E01",
+                listOf("https://rickandmortyapi.com/api/character/1", "https://rickandmortyapi.com/api/character/2"),
+                "https://rickandmortyapi.com/api/episode/1",
+                "2017-11-10T12:56:33.798Z"
+            )
+        )
+    )
+
     @Test
     fun `verify Get Episodes has been called`(): Unit = runBlocking {
 
-        val mockResponse = EpisodesResponseDto(
-            EpisodesInfoDto(51, 3, "https://rickandmortyapi.com/api/episode?page=2", null),
-            listOf(
-                EpisodeResultDto(
-                    1,
-                    "Pilot",
-                    "December 2, 2013",
-                    "S01E01",
-                    listOf("https://rickandmortyapi.com/api/character/1", "https://rickandmortyapi.com/api/character/2"),
-                    "https://rickandmortyapi.com/api/episode/1",
-                    "2017-11-10T12:56:33.798Z"
-                )
-            )
-        )
         given(mockApiRemoteDataSource.fetchRickAndMortyEpisodesData(1)).willReturn(mockResponse)
 
 
@@ -90,6 +91,17 @@ class EpisodeRepositoryTest {
         assertEquals("https://rickandmortyapi.com/api/episode/1", result[0].url)
         assertEquals("2017-11-10T12:56:33.798Z", result[0].created)
     }
+
+    @Test
+    fun `verify Get Episodes Info has been called`(): Unit = runBlocking {
+
+        given(mockApiRemoteDataSource.fetchRickAndMortyEpisodesData(1)).willReturn(mockResponse)
+
+        episodeRepository.getEpisodesInfo(1)
+
+        verify(mockApiRemoteDataSource).fetchRickAndMortyEpisodesData(1)
+    }
+
 }
 
 

--- a/app/src/test/java/rick_and_morty/rules/FakeRealmProvier.kt
+++ b/app/src/test/java/rick_and_morty/rules/FakeRealmProvier.kt
@@ -28,6 +28,10 @@ class FakeRealmInstance : RealmInstance {
         fakeDatabase.clear()
         fakeDatabase.addAll(episodesList.map { it.toRealmEpisode() })
     }
+
+    override fun clearEpisodesDatabase() {
+        fakeDatabase.clear()
+    }
 }
 
 


### PR DESCRIPTION
Introduced a refreshEpisodes function: This function is used to force a refresh of episodes data. It clears the local database and fetches fresh data from the API.

Updated unit tests: Refactored the existing unit tests to accommodate the new changes and added new tests to verify the correct operation of the new functions.
